### PR TITLE
Found the limit of PrimeCheckerJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # PrimeCheckerJS
 PrimeCheckerJS is a simple web-application which uses Miller-Rabin Primality Test algorithm to determine if a number is prime or composite. It uses BigInteger library to check large numbers for primality. 
+
+#Limit
+Upto 16 digits.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <h1>Prime Checker</h1>
         	<input class ="style-1" id="user_input"  type="number"></input>
         	<button  id="check" onclick="checkPrime()">Check</button>
+        	<p> Current limit is : 16 digits </p>
     </div>
 
     <script src="http://peterolson.github.com/BigInteger.js/BigInteger.min.js"></script>


### PR DESCRIPTION
#6  The limit is 16 digits. After 16 digits, it rounds off the number. Eg:
48112959837082099 (17 digit number) will be round off to 4811295983708210.
This 20 digits prime number - `48112959837082048697` cannot be detected by the script.